### PR TITLE
Fix default branch name for release drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,7 +3,7 @@ name: Release Drafter
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
We're using `main` and not `master`

Closes #<ticket number>

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help -->
- [ ] Tests
  - [ ] (not applicable?)
- [ ] Had a good time contributing?
