### PR TITLE
Rename AppConfig classname to remain consistent with its app name

### DIFF
--- a/django_postgres_hot_upgrade/__init__.py
+++ b/django_postgres_hot_upgrade/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = "django_postgres_hot_upgrade.app.PostgresHotUpdateConfig"
+default_app_config = "django_postgres_hot_upgrade.app.PostgresHotUpgradeConfig"

--- a/django_postgres_hot_upgrade/app.py
+++ b/django_postgres_hot_upgrade/app.py
@@ -24,7 +24,7 @@ def _on_connect(connection, **kwargs):
         _version_cache[connection.alias] = version
 
 
-class PostgresHotUpdateConfig(AppConfig):
+class PostgresHotUpgradeConfig(AppConfig):
 
     name = "django_postgres_hot_upgrade"
 


### PR DESCRIPTION
The Django app name is `postgres hot upgrade`, not update.

- [x] Tests
  - [x] (not applicable?)
- [x] Had a good time contributing?
